### PR TITLE
Switch default CPU flags from -mthumb to -marm (for IMX7)

### DIFF
--- a/bsps/arm/imx/config/imx7.cfg
+++ b/bsps/arm/imx/config/imx7.cfg
@@ -2,7 +2,7 @@ include $(RTEMS_ROOT)/make/custom/default.cfg
 
 RTEMS_CPU = arm
 
-CPU_CFLAGS = -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mtune=cortex-a7
+CPU_CFLAGS = -march=armv7-a -marm -mfpu=neon -mfloat-abi=hard -mtune=cortex-a7
 
 LDFLAGS = -Wl,--gc-sections
 


### PR DESCRIPTION
requires https://github.com/grisp/rtems-source-builder/pull/3